### PR TITLE
Add different default cache directory -  add cache directory as prop to cacheing files

### DIFF
--- a/lib/FileSystem.js
+++ b/lib/FileSystem.js
@@ -7,22 +7,22 @@
  *
  */
 
-import { Platform } from 'react-native';
-import pathLib from 'path';
-import RNFS from 'react-native-fs';
-import sha1 from 'crypto-js/sha1';
-import URL from 'url-parse';
+import { Platform } from "react-native";
+import pathLib from "path";
+import RNFS from "react-native-fs";
+import sha1 from "crypto-js/sha1";
+import URL from "url-parse";
 
 // Resolves if 'unlink' resolves or if the file doesn't exist.
-const RNFSUnlinkIfExists = (filename) => RNFS.exists(filename).then((exists) => {
-  if (exists) {
-    return RNFS.unlink(filename);
-  }
-  return Promise.resolve();
-});
+const RNFSUnlinkIfExists = (filename) =>
+  RNFS.exists(filename).then((exists) => {
+    if (exists) {
+      return RNFS.unlink(filename);
+    }
+    return Promise.resolve();
+  });
 
 export class FileSystem {
-  
   /**
    * All FileSystem instances will reference the cacheLock singleton "dictionary" to provide cache file locking in order to prevent concurrency race condition bugs.
    *
@@ -47,7 +47,6 @@ export class FileSystem {
   static cacheLock = {};
 
   static lockCacheFile(fileName, componentId) {
-
     // If file is already locked, add additional component lock, else create initial file lock.
     if (FileSystem.cacheLock[fileName]) {
       FileSystem.cacheLock[fileName][componentId] = true;
@@ -56,27 +55,27 @@ export class FileSystem {
       componentDict[componentId] = true;
       FileSystem.cacheLock[fileName] = componentDict;
     }
-
   }
 
   static unlockCacheFile(fileName, componentId) {
-
     // Delete component lock on cache file
     if (FileSystem.cacheLock[fileName]) {
       delete FileSystem.cacheLock[fileName][componentId];
     }
 
     // If no further component locks remain on cache file, delete filename property from cacheLock dictionary.
-    if (FileSystem.cacheLock[fileName] && Object.keys(FileSystem.cacheLock[fileName]).length === 0) {
+    if (
+      FileSystem.cacheLock[fileName] &&
+      Object.keys(FileSystem.cacheLock[fileName]).length === 0
+    ) {
       delete FileSystem.cacheLock[fileName];
     }
-
   }
 
   constructor(cachePruneTriggerLimit = null, fileDirName = null) {
     this.os = Platform.OS;
     this.cachePruneTriggerLimit = cachePruneTriggerLimit || 1024 * 1024 * 15; // Maximum size of image file cache in bytes before pruning occurs. Defaults to 15 MB.
-    fileDirName = fileDirName || 'react-native-image-cache-hoc'; // Namespace local file writing to this folder.
+    fileDirName = fileDirName || "cc-image-cache"; // Namespace local file writing to this folder.
     this.baseFilePath = this._setBaseFilePath(fileDirName);
   }
 
@@ -95,8 +94,9 @@ export class FileSystem {
    * @private
    */
   _setBaseFilePath(fileDirName = null) {
-    let baseFilePath = (this.os == 'ios') ? RNFS.CachesDirectoryPath : RNFS.DocumentDirectoryPath;
-    baseFilePath +=  '/' + fileDirName + '/';
+    let baseFilePath =
+      this.os == "ios" ? RNFS.CachesDirectoryPath : RNFS.DocumentDirectoryPath;
+    baseFilePath += "/" + fileDirName + "/";
     return baseFilePath;
   }
   /**
@@ -114,14 +114,15 @@ export class FileSystem {
    * @private
    */
   _validatePath(path, absolute = false) {
-    let resolvedPath = (absolute) ? pathLib.resolve(path) : pathLib.resolve(this.baseFilePath + path); // resolve turns any path into an absolute path (ie: /folder1/folder2/../example.js resolves to /folder1/example.js)
+    let resolvedPath = absolute
+      ? pathLib.resolve(path)
+      : pathLib.resolve(this.baseFilePath + path); // resolve turns any path into an absolute path (ie: /folder1/folder2/../example.js resolves to /folder1/example.js)
 
     if (resolvedPath.substr(0, this.baseFilePath.length) != this.baseFilePath) {
-      throw new Error(resolvedPath + ' is not a valid file path.');
+      throw new Error(resolvedPath + " is not a valid file path.");
     } else {
       return true;
     }
-
   }
 
   /**
@@ -145,40 +146,38 @@ export class FileSystem {
    * @returns fileName {string} - A SHA1 filename that is unique to the resource located at passed in URL and includes an appropriate extension.
    */
   async getFileNameFromUrl(url) {
-
     const urlParts = new URL(url);
-    const urlExt = urlParts.pathname.split('.').pop();
+    const urlExt = urlParts.pathname.split(".").pop();
 
     let extension = null;
-    switch(urlExt) {
-      case 'png':
-      case 'PNG':
-        extension = 'png';
+    switch (urlExt) {
+      case "png":
+      case "PNG":
+        extension = "png";
         break;
-      case 'gif':
-      case 'GIF':
-        extension = 'gif';
+      case "gif":
+      case "GIF":
+        extension = "gif";
         break;
-      case 'jpg':
-      case 'JPG':
-      case 'jpeg':
-      case 'JPEG':
-        extension = 'jpg';
+      case "jpg":
+      case "JPG":
+      case "jpeg":
+      case "JPEG":
+        extension = "jpg";
         break;
-      case 'BMP':
-      case 'bmp':
-        extension = 'bmp';
+      case "BMP":
+      case "bmp":
+        extension = "bmp";
         break;
       default:
         extension = await this.getExtensionFromContentTypeHeader(url);
     }
 
     if (!extension) {
-      throw new Error('Unable to determine remote image filetype.');
+      throw new Error("Unable to determine remote image filetype.");
     }
 
-    return sha1(url).toString() + '.' + extension;
-
+    return sha1(url).toString() + "." + extension;
   }
 
   /**
@@ -191,46 +190,42 @@ export class FileSystem {
    * @returns extension {string} - A file extension appropriate for remote file.
    */
   async getExtensionFromContentTypeHeader(url) {
-
     let extension = null;
     let contentType = null;
 
     // Request "Content-type" header from server.
-    try{
-
+    try {
       const response = await fetch(url, {
-        method: 'HEAD'
+        method: "HEAD",
       });
 
-      if (response.headers.get('content-type')) {
-        const rawContentType = response.headers.get('content-type'); // headers are case-insensitive, fetch standard is all lower case.
+      if (response.headers.get("content-type")) {
+        const rawContentType = response.headers.get("content-type"); // headers are case-insensitive, fetch standard is all lower case.
         contentType = rawContentType.toLowerCase();
       }
-
     } catch (error) {
       console.warn(error); // eslint-disable-line no-console
     }
 
     // Use content type header to determine extension.
-    switch(contentType) {
-      case 'image/png':
-        extension = 'png';
+    switch (contentType) {
+      case "image/png":
+        extension = "png";
         break;
-      case 'image/gif':
-        extension = 'gif';
+      case "image/gif":
+        extension = "gif";
         break;
-      case 'image/jpeg':
-        extension = 'jpg';
+      case "image/jpeg":
+        extension = "jpg";
         break;
-      case 'image/bmp':
-        extension = 'bmp';
+      case "image/bmp":
+        extension = "bmp";
         break;
       default:
         extension = null;
     }
 
     return extension;
-
   }
 
   /**
@@ -243,33 +238,25 @@ export class FileSystem {
    * @returns {Promise} promise that resolves to the local file path of downloaded url file.
    */
   async getLocalFilePathFromUrl(url, permanent) {
-
     let filePath = null;
 
     let fileName = await this.getFileNameFromUrl(url);
 
-    let permanentFileExists = this.exists('permanent/' + fileName);
-    let cacheFileExists = this.exists('cache/' + fileName);
+    let permanentFileExists = this.exists("permanent/" + fileName);
+    let cacheFileExists = this.exists("cache/" + fileName);
 
     let exists = await Promise.all([permanentFileExists, cacheFileExists]);
 
     if (exists[0]) {
-
-      filePath = this.baseFilePath + 'permanent/' + fileName;
-
+      filePath = this.baseFilePath + "permanent/" + fileName;
     } else if (exists[1]) {
-
-      filePath = this.baseFilePath + 'cache/' + fileName;
-
+      filePath = this.baseFilePath + "cache/" + fileName;
     } else {
-
       let result = await this.fetchFile(url, permanent, null, true); // Clobber must be true to allow concurrent CacheableImage components with same source url (ie: bullet point images).
       filePath = result.path;
-
     }
 
     return filePath;
-
   }
 
   /**
@@ -283,15 +270,19 @@ export class FileSystem {
    * @returns {Promise} promise that resolves to an object that contains the local path of the downloaded file and the filename.
    */
   async fetchFile(url, permanent = false, fileName = null, clobber = false) {
-
-    fileName = fileName || await this.getFileNameFromUrl(url);
-    let path = this.baseFilePath + (permanent ? 'permanent' : 'cache') + '/' + fileName;
+    fileName = fileName || (await this.getFileNameFromUrl(url));
+    let path =
+      this.baseFilePath + (permanent ? "permanent" : "cache") + "/" + fileName;
     this._validatePath(path, true);
 
     // Clobber logic
-    let fileExistsAtPath = await this.exists((permanent ? 'permanent/' : 'cache/') + fileName);
+    let fileExistsAtPath = await this.exists(
+      (permanent ? "permanent/" : "cache/") + fileName
+    );
     if (!clobber && fileExistsAtPath) {
-      throw new Error('A file already exists at ' + path + ' and clobber is set to false.');
+      throw new Error(
+        "A file already exists at " + path + " and clobber is set to false."
+      );
     }
 
     // Logic here prunes cache directory on "cache" writes to ensure cache doesn't get too large.
@@ -302,17 +293,17 @@ export class FileSystem {
     // Hit network and download file to local disk.
     try {
       const cacheDirExists = await this.exists(
-        permanent ? 'permanent' : 'cache'
+        permanent ? "permanent" : "cache"
       );
       if (!cacheDirExists) {
         await RNFS.mkdir(
-          `${this.baseFilePath}${permanent ? 'permanent' : 'cache'}`
+          `${this.baseFilePath}${permanent ? "permanent" : "cache"}`
         );
       }
 
       const { promise } = RNFS.downloadFile({
         fromUrl: url,
-        toFile: path
+        toFile: path,
       });
       await promise;
     } catch (error) {
@@ -322,9 +313,8 @@ export class FileSystem {
 
     return {
       path,
-      fileName: pathLib.basename(path)
+      fileName: pathLib.basename(path),
     };
-
   }
 
   /**
@@ -335,14 +325,13 @@ export class FileSystem {
    * @returns {Promise}
    */
   async pruneCache() {
-
     // If cache directory does not exist yet there's no need for pruning.
-    if (!await this.exists('cache')) {
+    if (!(await this.exists("cache"))) {
       return;
     }
 
     // Get directory contents
-    let dirContents = await RNFS.readDir(this.baseFilePath + 'cache');
+    let dirContents = await RNFS.readDir(this.baseFilePath + "cache");
 
     // Sort dirContents in order of oldest to newest file.
     dirContents.sort((a, b) => {
@@ -355,25 +344,23 @@ export class FileSystem {
 
     // Prune cache if current cache size is too big.
     if (currentCacheSize > this.cachePruneTriggerLimit) {
-
       let overflowSize = currentCacheSize - this.cachePruneTriggerLimit;
 
       // Keep deleting cached files so long as the current cache size is larger than the size required to trigger cache pruning, or until
       // all cache files have been evaluated.
       while (overflowSize > 0 && dirContents.length) {
-
         let contentFile = dirContents.shift();
 
         // Only prune unlocked files from cache
-        if (!FileSystem.cacheLock[contentFile.name] && this._validatePath('cache/' + contentFile.name)) {
+        if (
+          !FileSystem.cacheLock[contentFile.name] &&
+          this._validatePath("cache/" + contentFile.name)
+        ) {
           overflowSize -= parseInt(contentFile.size);
-          RNFSUnlinkIfExists(this.baseFilePath + 'cache/' + contentFile.name);
+          RNFSUnlinkIfExists(this.baseFilePath + "cache/" + contentFile.name);
         }
-
       }
-
     }
-
   }
 
   /**
@@ -391,9 +378,7 @@ export class FileSystem {
     } catch (error) {
       return false;
     }
-
   }
-
 }
 
 /**
@@ -401,7 +386,10 @@ export class FileSystem {
  *
  * @returns {FileSystem}
  */
-export default function FileSystemFactory(cachePruneTriggerLimit = null, fileDirName = null) {
+export default function FileSystemFactory(
+  cachePruneTriggerLimit = null,
+  fileDirName = null
+) {
   if (!(this instanceof FileSystem)) {
     return new FileSystem(cachePruneTriggerLimit, fileDirName);
   }

--- a/lib/imageCacheHoc.js
+++ b/lib/imageCacheHoc.js
@@ -14,25 +14,45 @@
  */
 
 // Load dependencies.
-import React from 'react';
-import { Platform, ViewPropTypes } from 'react-native';
-import PropTypes from 'prop-types';
-import FileSystemFactory, { FileSystem } from '../lib/FileSystem';
-import traverse from 'traverse';
-import validator from 'validator';
-import uuid from 'react-native-uuid';
+import React from "react";
+import { Platform, ViewPropTypes } from "react-native";
+import PropTypes from "prop-types";
+import FileSystemFactory, { FileSystem } from "../lib/FileSystem";
+import traverse from "traverse";
+import validator from "validator";
+import uuid from "react-native-uuid";
 
 export default function imageCacheHoc(Image, options = {}) {
-
   // Validate options
-  if (options.validProtocols && !Array.isArray(options.validProtocols)) { throw new Error('validProtocols option must be an array of protocol strings.'); }
-  if (options.fileHostWhitelist && !Array.isArray(options.fileHostWhitelist)) { throw new Error('fileHostWhitelist option must be an array of host strings.'); }
-  if (options.cachePruneTriggerLimit && !Number.isInteger(options.cachePruneTriggerLimit) ) { throw new Error('cachePruneTriggerLimit option must be an integer.'); }
-  if (options.fileDirName && typeof options.fileDirName !== 'string') { throw new Error('fileDirName option must be string'); }
-  if (options.defaultPlaceholder && (!options.defaultPlaceholder.component || !options.defaultPlaceholder.props)) { throw new Error('defaultPlaceholder option object must include "component" and "props" properties (props can be an empty object)'); }
+  if (options.validProtocols && !Array.isArray(options.validProtocols)) {
+    throw new Error(
+      "validProtocols option must be an array of protocol strings."
+    );
+  }
+  if (options.fileHostWhitelist && !Array.isArray(options.fileHostWhitelist)) {
+    throw new Error(
+      "fileHostWhitelist option must be an array of host strings."
+    );
+  }
+  if (
+    options.cachePruneTriggerLimit &&
+    !Number.isInteger(options.cachePruneTriggerLimit)
+  ) {
+    throw new Error("cachePruneTriggerLimit option must be an integer.");
+  }
+  if (options.fileDirName && typeof options.fileDirName !== "string") {
+    throw new Error("fileDirName option must be string");
+  }
+  if (
+    options.defaultPlaceholder &&
+    (!options.defaultPlaceholder.component || !options.defaultPlaceholder.props)
+  ) {
+    throw new Error(
+      'defaultPlaceholder option object must include "component" and "props" properties (props can be an empty object)'
+    );
+  }
 
   return class extends React.PureComponent {
-
     static propTypes = {
       fileHostWhitelist: PropTypes.array,
       source: PropTypes.object.isRequired,
@@ -40,8 +60,8 @@ export default function imageCacheHoc(Image, options = {}) {
       style: ViewPropTypes.style,
       placeholder: PropTypes.shape({
         component: PropTypes.func,
-        props: PropTypes.object
-      })
+        props: PropTypes.object,
+      }),
     };
 
     /**
@@ -55,17 +75,18 @@ export default function imageCacheHoc(Image, options = {}) {
      * @param permanent {Boolean} - whether the file should be saved to the tmp or permanent cache directory.
      * @returns {Promise} promise that resolves to an object that contains cached file info.
      */
-    static async cacheFile(url, permanent = false) {
-
-      const fileSystem = FileSystemFactory();
-      const localFilePath = await fileSystem.getLocalFilePathFromUrl(url, permanent);
+    static async cacheFile(url, permanent = false, fileDirName = null) {
+      const fileSystem = FileSystemFactory(null, fileDirName);
+      const localFilePath = await fileSystem.getLocalFilePathFromUrl(
+        url,
+        permanent
+      );
 
       return {
         url: url,
-        cacheType: (permanent ? 'permanent' : 'cache'),
-        localFilePath
+        cacheType: permanent ? "permanent" : "cache",
+        localFilePath,
       };
-
     }
 
     /**
@@ -76,15 +97,16 @@ export default function imageCacheHoc(Image, options = {}) {
      * @returns {Promise} promise that resolves to an object that contains the flush results.
      */
     static async flush() {
-
       const fileSystem = FileSystemFactory();
-      const results = await Promise.all([fileSystem.unlink('permanent'), fileSystem.unlink('cache')]);
+      const results = await Promise.all([
+        fileSystem.unlink("permanent"),
+        fileSystem.unlink("cache"),
+      ]);
 
       return {
         permanentDirFlushed: results[0],
-        cacheDirFlushed: results[1]
+        cacheDirFlushed: results[1],
       };
-
     }
 
     constructor(props) {
@@ -92,7 +114,7 @@ export default function imageCacheHoc(Image, options = {}) {
 
       // Set initial state
       this.state = {
-        localFilePath: null
+        localFilePath: null,
       };
 
       // Assign component unique ID for cache locking.
@@ -103,50 +125,58 @@ export default function imageCacheHoc(Image, options = {}) {
 
       // Set default options
       this.options = {
-        validProtocols: options.validProtocols || ['https'],
+        validProtocols: options.validProtocols || ["https"],
         fileHostWhitelist: options.fileHostWhitelist || [],
-        cachePruneTriggerLimit: options.cachePruneTriggerLimit || 1024 * 1024 * 15, // Maximum size of image file cache in bytes before pruning occurs. Defaults to 15 MB.
+        cachePruneTriggerLimit:
+          options.cachePruneTriggerLimit || 1024 * 1024 * 15, // Maximum size of image file cache in bytes before pruning occurs. Defaults to 15 MB.
         fileDirName: options.fileDirName || null, // Namespace local file writing to this directory. Defaults to 'react-native-image-cache-hoc'.
         defaultPlaceholder: options.defaultPlaceholder || null, // Default placeholder component to render while remote image file is downloading. Can be overridden with placeholder prop. Defaults to <Image> component with style prop passed through.
       };
 
       // Init file system lib
-      this.fileSystem = FileSystemFactory(this.options.cachePruneTriggerLimit, this.options.fileDirName);
+      this.fileSystem = FileSystemFactory(
+        this.options.cachePruneTriggerLimit,
+        this.options.fileDirName
+      );
 
       // Validate input
       this._validateImageComponent();
-
     }
 
     _validateImageComponent() {
-
       // Define validator options
-      let validatorUrlOptions = { protocols: this.options.validProtocols, require_protocol: true };
+      let validatorUrlOptions = {
+        protocols: this.options.validProtocols,
+        require_protocol: true,
+      };
       if (this.options.fileHostWhitelist.length) {
         validatorUrlOptions.host_whitelist = this.options.fileHostWhitelist;
       }
 
       // Validate source prop to be a valid web accessible url.
       if (
-        !traverse(this.props).get(['source', 'uri'])
-        || !validator.isURL(traverse(this.props).get(['source', 'uri']), validatorUrlOptions)
+        !traverse(this.props).get(["source", "uri"]) ||
+        !validator.isURL(
+          traverse(this.props).get(["source", "uri"]),
+          validatorUrlOptions
+        )
       ) {
-        throw new Error('Invalid source prop. <CacheableImage> props.source.uri should be a web accessible url with a valid protocol and host. NOTE: Default valid protocol is https, default valid hosts are *.');
+        throw new Error(
+          "Invalid source prop. <CacheableImage> props.source.uri should be a web accessible url with a valid protocol and host. NOTE: Default valid protocol is https, default valid hosts are *."
+        );
       } else {
         return true;
       }
-
     }
 
     // Async calls to local FS or network should occur here.
     // See: https://reactjs.org/docs/react-component.html#componentdidmount
     async componentDidMount() {
-
       // Track component mount status to avoid calling setState() on unmounted component.
       this._isMounted = true;
 
       // Set url from source prop
-      const url = traverse(this.props).get(['source', 'uri']);
+      const url = traverse(this.props).get(["source", "uri"]);
 
       // Add a cache lock to file with this name (prevents concurrent <CacheableImage> components from pruning a file with this name from cache).
       const fileName = await this.fileSystem.getFileNameFromUrl(url);
@@ -154,7 +184,6 @@ export default function imageCacheHoc(Image, options = {}) {
 
       // Init the image cache logic
       await this._loadImage(url);
-
     }
 
     /**
@@ -165,10 +194,9 @@ export default function imageCacheHoc(Image, options = {}) {
      * @param nextProps {Object} - Props that will be passed to component.
      */
     async componentWillReceiveProps(nextProps) {
-
       // Set urls from source prop data
-      const url = traverse(this.props).get(['source', 'uri']);
-      const nextUrl = traverse(nextProps).get(['source', 'uri']);
+      const url = traverse(this.props).get(["source", "uri"]);
+      const nextUrl = traverse(nextProps).get(["source", "uri"]);
 
       // Do nothing if url has not changed.
       if (url === nextUrl) return;
@@ -182,7 +210,6 @@ export default function imageCacheHoc(Image, options = {}) {
 
       // Init the image cache logic
       await this._loadImage(nextUrl);
-
     }
 
     /**
@@ -194,12 +221,14 @@ export default function imageCacheHoc(Image, options = {}) {
      * @private
      */
     async _loadImage(url) {
-
       // Check local fs for file, fallback to network and write file to disk if local file not found.
       const permanent = this.props.permanent ? true : false;
       let localFilePath = null;
       try {
-        localFilePath = await this.fileSystem.getLocalFilePathFromUrl(url, permanent);
+        localFilePath = await this.fileSystem.getLocalFilePathFromUrl(
+          url,
+          permanent
+        );
       } catch (error) {
         console.warn(error); // eslint-disable-line no-console
       }
@@ -210,47 +239,54 @@ export default function imageCacheHoc(Image, options = {}) {
       if (this._isMounted && localFilePath) {
         this.setState({ localFilePath });
       }
-
     }
 
     async componentWillUnmount() {
-
       // Track component mount status to avoid calling setState() on unmounted component.
       this._isMounted = false;
 
       // Remove component cache lock on associated image file on component teardown.
-      let fileName = await this.fileSystem.getFileNameFromUrl(traverse(this.props).get(['source', 'uri']));
+      let fileName = await this.fileSystem.getFileNameFromUrl(
+        traverse(this.props).get(["source", "uri"])
+      );
       FileSystem.unlockCacheFile(fileName, this.componentId);
-
     }
 
     render() {
-
       // If media loaded, render full image component, else render placeholder.
       if (this.state.localFilePath) {
-
         // Build platform specific file resource uri.
-        const localFileUri = (Platform.OS == 'ios') ? this.state.localFilePath : 'file://' + this.state.localFilePath; // Android requires the traditional 3 prefixed slashes file:/// in a localhost absolute file uri.
+        const localFileUri =
+          Platform.OS == "ios"
+            ? this.state.localFilePath
+            : "file://" + this.state.localFilePath; // Android requires the traditional 3 prefixed slashes file:/// in a localhost absolute file uri.
 
         // Extract props proprietary to this HOC before passing props through.
         let { permanent, ...filteredProps } = this.props; // eslint-disable-line no-unused-vars
 
-        let props = Object.assign({}, filteredProps, { source: { uri: localFileUri } });
-        return (<Image {...props} />);
+        let props = Object.assign({}, filteredProps, {
+          source: { uri: localFileUri },
+        });
+        return <Image {...props} />;
       } else {
-
         if (this.props.placeholder) {
-          return (<this.props.placeholder.component {...this.props.placeholder.props} />);
+          return (
+            <this.props.placeholder.component
+              {...this.props.placeholder.props}
+            />
+          );
         } else if (this.options.defaultPlaceholder) {
-          return (<this.options.defaultPlaceholder.component {...this.options.defaultPlaceholder.props} />);
+          return (
+            <this.options.defaultPlaceholder.component
+              {...this.options.defaultPlaceholder.props}
+            />
+          );
         } else {
-          return (<Image style={this.props.style ? this.props.style : undefined} />);
+          return (
+            <Image style={this.props.style ? this.props.style : undefined} />
+          );
         }
-
       }
-
     }
-
   };
-
 }

--- a/lib/imageCacheHoc.js
+++ b/lib/imageCacheHoc.js
@@ -182,6 +182,7 @@ export default function imageCacheHoc(Image, options = {}) {
       // Add a cache lock to file with this name (prevents concurrent <CacheableImage> components from pruning a file with this name from cache).
       const fileName = await this.fileSystem.getFileNameFromUrl(url);
       FileSystem.lockCacheFile(fileName, this.componentId);
+      console.log("fileName: ", fileName);
 
       // Init the image cache logic
       await this._loadImage(url);

--- a/lib/imageCacheHoc.js
+++ b/lib/imageCacheHoc.js
@@ -97,8 +97,8 @@ export default function imageCacheHoc(Image, options = {}) {
      *
      * @returns {Promise} promise that resolves to an object that contains the flush results.
      */
-    static async flush() {
-      const fileSystem = FileSystemFactory();
+    static async flush(fileDirName = null) {
+      const fileSystem = FileSystemFactory(null, fileDirName);
       const results = await Promise.all([
         fileSystem.unlink("permanent"),
         fileSystem.unlink("cache"),

--- a/lib/imageCacheHoc.js
+++ b/lib/imageCacheHoc.js
@@ -182,7 +182,6 @@ export default function imageCacheHoc(Image, options = {}) {
       // Add a cache lock to file with this name (prevents concurrent <CacheableImage> components from pruning a file with this name from cache).
       const fileName = await this.fileSystem.getFileNameFromUrl(url);
       FileSystem.lockCacheFile(fileName, this.componentId);
-      console.log("fileName: ", fileName);
 
       // Init the image cache logic
       await this._loadImage(url);

--- a/lib/imageCacheHoc.js
+++ b/lib/imageCacheHoc.js
@@ -15,12 +15,13 @@
 
 // Load dependencies.
 import React from "react";
-import { Platform, ViewPropTypes } from "react-native";
+import { Platform } from "react-native";
 import PropTypes from "prop-types";
 import FileSystemFactory, { FileSystem } from "../lib/FileSystem";
 import traverse from "traverse";
 import validator from "validator";
 import uuid from "react-native-uuid";
+import { ViewPropTypes } from "deprecated-react-native-prop-types";
 
 export default function imageCacheHoc(Image, options = {}) {
   // Validate options


### PR DESCRIPTION
Adding in a default cache directory, and the ability to explicitly use a specific cache directory. 

Reason:
We were "double" caching, as in some instances the custom cache directory we were using would be null.