### PR TITLE
patch up some logs

### DIFF
--- a/lib/FileSystem.js
+++ b/lib/FileSystem.js
@@ -170,62 +170,14 @@ export class FileSystem {
         extension = "bmp";
         break;
       default:
-        extension = await this.getExtensionFromContentTypeHeader(url);
+        break;
     }
 
     if (!extension) {
-      throw new Error("Unable to determine remote image filetype.");
+      sha1(url).toString();
     }
 
     return sha1(url).toString() + "." + extension;
-  }
-
-  /**
-   *
-   * Used to determine appropriate file extension for a remote file that doesn't include
-   * an extension in the url. This method will attempt to determine extension using server
-   * "Content-Type" response header.
-   *
-   * @param url {String} - An absolute url.
-   * @returns extension {string} - A file extension appropriate for remote file.
-   */
-  async getExtensionFromContentTypeHeader(url) {
-    let extension = null;
-    let contentType = null;
-
-    // Request "Content-type" header from server.
-    try {
-      const response = await fetch(url, {
-        method: "HEAD",
-      });
-
-      if (response.headers.get("content-type")) {
-        const rawContentType = response.headers.get("content-type"); // headers are case-insensitive, fetch standard is all lower case.
-        contentType = rawContentType.toLowerCase();
-      }
-    } catch (error) {
-      console.warn(error); // eslint-disable-line no-console
-    }
-
-    // Use content type header to determine extension.
-    switch (contentType) {
-      case "image/png":
-        extension = "png";
-        break;
-      case "image/gif":
-        extension = "gif";
-        break;
-      case "image/jpeg":
-        extension = "jpg";
-        break;
-      case "image/bmp":
-        extension = "bmp";
-        break;
-      default:
-        extension = null;
-    }
-
-    return extension;
   }
 
   /**

--- a/lib/imageCacheHoc.js
+++ b/lib/imageCacheHoc.js
@@ -194,7 +194,7 @@ export default function imageCacheHoc(Image, options = {}) {
      *
      * @param nextProps {Object} - Props that will be passed to component.
      */
-    async componentWillReceiveProps(nextProps) {
+    async UNSAFE_componentWillReceiveProps(nextProps) {
       // Set urls from source prop data
       const url = traverse(this.props).get(["source", "uri"]);
       const nextUrl = traverse(nextProps).get(["source", "uri"]);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-image-cache-hoc",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "React Native Higher Order Component that adds advanced caching functionality to the react native Image component.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
> [!NOTE]  
> This is certainly a "quick fix" PR for a library we likely need to replace


part of parent PR: https://github.com/CompanyCam/companycam-mobile/pull/6236

**removes:**
- error thrown when no extension is present
- warning about no longer using component lifecycle methods

