### PR TITLE
Upgrade Validator

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,6 @@
     "react-native-uuid": "^1.4.9",
     "traverse": "^0.6.6",
     "url-parse": "^1.2.0",
-    "validator": "^9.0.0"
+    "validator": "^13.15.23"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5733,10 +5733,10 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
-validator@^9.0.0:
-  version "9.4.1"
-  resolved "http://registry.npmjs.org/validator/-/validator-9.4.1.tgz"
-  integrity sha512-YV5KjzvRmSyJ1ee/Dm5UED0G+1L4GZnLN3w6/T+zZm8scVua4sOhYKWTUrKa0H/tMiJyO9QLHMPN+9mB/aMunA==
+validator@^13.15.23:
+  version "13.15.23"
+  resolved "https://registry.yarnpkg.com/validator/-/validator-13.15.23.tgz#59a874f84e4594588e3409ab1edbe64e96d0c62d"
+  integrity sha512-4yoz1kEWqUjzi5zsPbAS/903QXSYp0UOtHsPpp7p9rHAw/W+dkInskAE386Fat3oKRROwO98d9ZB0G4cObgUyw==
 
 vary@~1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Validator version 9 has a security vulnerability called out by [dependabot](https://github.com/CompanyCam/companycam-mobile/security/dependabot/203). This version bump will resolve it.

Testing:
- Navigate to the AssetGallery and ensure images are still loading as expected
- Edit Photo and confirm it still working as expected.
- Confirmed calls to caching worked as expected

<img width="606" height="195" alt="image" src="https://github.com/user-attachments/assets/dfcda436-e836-49db-8892-2380e98dd4a6" />

Printed out the proper directory.

I am deeply curious how effective this library is being it is no longer maintained, this might be an area where we can improve the application.

