### PR TITLE
chore: drop validator dep, replace isURL with native URL parser

### DIFF
--- a/lib/imageCacheHoc.js
+++ b/lib/imageCacheHoc.js
@@ -30,12 +30,8 @@ function isValidUrl(uri, { protocols, host_whitelist }) {
     return false;
   }
   const proto = parsed.protocol.replace(/:$/, "");
-  if (protocols && protocols.length && !protocols.includes(proto)) return false;
-  if (
-    host_whitelist &&
-    host_whitelist.length &&
-    !host_whitelist.includes(parsed.hostname)
-  )
+  if (protocols?.length && !protocols.includes(proto)) return false;
+  if (host_whitelist?.length && !host_whitelist.includes(parsed.hostname))
     return false;
   return true;
 }
@@ -164,14 +160,11 @@ export default function imageCacheHoc(Image, options = {}) {
     _validateImageComponent() {
       const urlOptions = {
         protocols: this.options.validProtocols,
+        host_whitelist: this.options.fileHostWhitelist,
       };
-      if (this.options.fileHostWhitelist.length) {
-        urlOptions.host_whitelist = this.options.fileHostWhitelist;
-      }
 
       // Validate source prop to be a valid web accessible url.
       if (
-        !traverse(this.props).get(["source", "uri"]) ||
         !isValidUrl(traverse(this.props).get(["source", "uri"]), urlOptions)
       ) {
         throw new Error(

--- a/lib/imageCacheHoc.js
+++ b/lib/imageCacheHoc.js
@@ -19,9 +19,26 @@ import { Platform } from "react-native";
 import PropTypes from "prop-types";
 import FileSystemFactory, { FileSystem } from "../lib/FileSystem";
 import traverse from "traverse";
-import validator from "validator";
 import uuid from "react-native-uuid";
 import { ViewPropTypes } from "deprecated-react-native-prop-types";
+
+function isValidUrl(uri, { protocols, host_whitelist }) {
+  let parsed;
+  try {
+    parsed = new URL(uri);
+  } catch {
+    return false;
+  }
+  const proto = parsed.protocol.replace(/:$/, "");
+  if (protocols && protocols.length && !protocols.includes(proto)) return false;
+  if (
+    host_whitelist &&
+    host_whitelist.length &&
+    !host_whitelist.includes(parsed.hostname)
+  )
+    return false;
+  return true;
+}
 
 export default function imageCacheHoc(Image, options = {}) {
   // Validate options
@@ -145,22 +162,17 @@ export default function imageCacheHoc(Image, options = {}) {
     }
 
     _validateImageComponent() {
-      // Define validator options
-      let validatorUrlOptions = {
+      const urlOptions = {
         protocols: this.options.validProtocols,
-        require_protocol: true,
       };
       if (this.options.fileHostWhitelist.length) {
-        validatorUrlOptions.host_whitelist = this.options.fileHostWhitelist;
+        urlOptions.host_whitelist = this.options.fileHostWhitelist;
       }
 
       // Validate source prop to be a valid web accessible url.
       if (
         !traverse(this.props).get(["source", "uri"]) ||
-        !validator.isURL(
-          traverse(this.props).get(["source", "uri"]),
-          validatorUrlOptions
-        )
+        !isValidUrl(traverse(this.props).get(["source", "uri"]), urlOptions)
       ) {
         throw new Error(
           "Invalid source prop. <CacheableImage> props.source.uri should be a web accessible url with a valid protocol and host. NOTE: Default valid protocol is https, default valid hosts are *."

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "prop-types": "^15.6.0",
     "react-native-uuid": "^1.4.9",
     "traverse": "^0.6.6",
-    "url-parse": "^1.2.0",
-    "validator": "^13.15.23"
+    "url-parse": "^1.2.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5733,11 +5733,6 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
-validator@^13.15.23:
-  version "13.15.23"
-  resolved "https://registry.yarnpkg.com/validator/-/validator-13.15.23.tgz#59a874f84e4594588e3409ab1edbe64e96d0c62d"
-  integrity sha512-4yoz1kEWqUjzi5zsPbAS/903QXSYp0UOtHsPpp7p9rHAw/W+dkInskAE386Fat3oKRROwO98d9ZB0G4cObgUyw==
-
 vary@~1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz"


### PR DESCRIPTION
## Summary

- Drops the `validator` package (~280 KB in JS bundle, measured via Expo Atlas in the consuming mobile app).
- Replaces the single `validator.isURL()` callsite in `lib/imageCacheHoc.js` with a small native `URL`-based helper.
- `require_protocol: true` is no longer needed — `new URL()` without a base already requires a protocol, so bare strings like `example.com/foo` throw and return `false`.

## Test plan

- [x] `grep -rn validator lib/ tests/` returns nothing
- [x] `yarn install` regenerates lockfile without `validator`
- [ ] Bump the commit SHA in the mobile repo's `package.json` and verify the bundle size drop

🤖 Generated with [Claude Code](https://claude.com/claude-code)